### PR TITLE
Make webpack import ./src/styles/*.scss as global

### DIFF
--- a/src/components/AppLayout.js
+++ b/src/components/AppLayout.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import 'styles/app.scss';
 
 const AppLayout = (props) => {
   return (

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,3 +1,7 @@
+// This stylesheet contains the global styles for CoreLayout
+// It's not a component's style (names are not mangled and it's not InlineCss)
+// but rather it's your usual stylesheet that you'd include in a <link rel=... /> tag.
+
 @import 'base';
 
 // Some best-practice CSS that's useful for most apps
@@ -21,20 +25,7 @@ body {
   font-family: $fonts;
 }
 
-// global styles need to be added into the :global {} block
-:global {
-  .clearfix {
-    clear: both;
-  }
-}
 
-// or explicitly made global with :global(.class-name) { ... }
-:global(.top-right) {
-  position: absolute;
-  top: 0;
-  right: 0;
-}
-
-:global(#root) {
-  font-family: $fonts;
+#app-layout {
+  background-color: red;
 }

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,7 +1,3 @@
-// This stylesheet contains the global styles for CoreLayout
-// It's not a component's style (names are not mangled and it's not InlineCss)
-// but rather it's your usual stylesheet that you'd include in a <link rel=... /> tag.
-
 @import 'base';
 
 // Some best-practice CSS that's useful for most apps
@@ -24,4 +20,3 @@ html, body {
 body {
   font-family: $fonts;
 }
-

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -25,7 +25,3 @@ body {
   font-family: $fonts;
 }
 
-
-#app-layout {
-  background-color: red;
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,19 +66,24 @@ const webpackconfig = {
         test: /\.json$/,
         loader: 'json',
       },
+      // Any .scss file in ./src/... *except* those in ./src/styles/
+      // are local css modules. the class names and ids will be changed to:
+      // [name]-[local]-[hash:base64:5]
       {
         test: /\.scss$/,
-        include: /src/,
+        include: /src\/(?!styles).+/,
         loaders: [
           'style',
-          'css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
+          'css?modules&sourceMap&importLoaders=1&localIdentName=[name]-[local]-[hash:base64:5]',
           'postcss',
           'sass',
         ],
       },
+      // Any .scss files in ./src/styles are treated as normal (not local)
+      // sass files, and so class names and ids will remain as specified
       {
         test: /\.scss$/,
-        exclude: /src/,
+        include: /src\/styles/,
         loader: 'style!css?sourceMap!postcss!sass',
       },
       // File loaders


### PR DESCRIPTION
All styles in `./src/styles/` will be imported as normal css, everything else will have local class names. 
