### PR TITLE
Devtools only in develop

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -39,7 +39,7 @@ const config = {
       'react-router-bootstrap',
     ],
     output: {
-      publicPath: '',
+      publicPath: '/',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react-router": "^2.0.0-rc5",
     "react-router-bootstrap": "^0.20.1",
     "redux": "^3.0.5",
-    "redux-actions": "^0.9.0",
     "redux-logger": "^2.3.2",
     "redux-simple-router": "^2.0.3",
     "redux-thunk": "^1.0.3",

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
-import DevTools from 'containers/DevTools';
 
 export default class Root extends React.Component {
 
@@ -17,7 +16,8 @@ export default class Root extends React.Component {
 
   // redux devtools pane
   get devTools() {
-    if (__DEBUG__) {
+    if (DEVELOPMENT) {
+      const DevTools = require('./DevTools');
       return <DevTools />;
     }
   }
@@ -29,7 +29,7 @@ export default class Root extends React.Component {
           <Router history={this.props.history}>
             {this.props.routes}
           </Router>
-          { __DEBUG__ ? <DevTools /> : null }
+          {this.devTools}
         </div>
       </Provider>
     );

--- a/src/pages/LandingPage/LandingPage.js
+++ b/src/pages/LandingPage/LandingPage.js
@@ -6,12 +6,12 @@ import debug from 'debug';
 import { autobind } from 'core-decorators';
 import LandingPageHero from './LandingPageHero';
 
-const log = debug('landing-page:info');
-const error = debug('landing-page:error');
-
 if (__DEBUG__) {
   debug.enable('landing-page:*');
 }
+
+const log = debug('landing-page:info');
+const error = debug('landing-page:error');
 
 export class LandingPage extends React.Component {
 

--- a/src/redux/configure-store.js
+++ b/src/redux/configure-store.js
@@ -23,7 +23,6 @@ export default function configureStore(initialState, browserHistory) {
   const store = middleware(createStore)(rootReducer, initialState);
 
   if (__DEBUG__) {
-    console.log('listenForReplays', store);
     // listen for route replays (devtools)
     routerMiddleware.listenForReplays(store, ({ routing }) => routing);
   }

--- a/src/redux/root-reducer.js
+++ b/src/redux/root-reducer.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import { routeReducer as routing } from 'redux-simple-router';
-import auth from 'redux/modules/auth/auth-reducer';
+import auth from './modules/auth/auth-reducer';
 
 export default combineReducers({
   auth,


### PR DESCRIPTION
Only add redux-devtools in the bundle if we're in `DEVELOPMENT / __DEBUG__` mode.
