### PR TITLE
Lock eslint to version 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "css-loader": "^0.23.1",
     "cssnano": "^3.5.2",
     "eslint": "2.2.0",
-    "eslint-config-airbnb": "^6.0.2",
+    "eslint-config-airbnb": "6.0.2",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "core-decorators": "^0.11.0",
     "css-loader": "^0.23.1",
     "cssnano": "^3.5.2",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "eslint-config-airbnb": "^6.0.2",
     "eslint-loader": "^1.3.0",
     "eslint-plugin-babel": "^3.1.0",


### PR DESCRIPTION
As described by [@ro-savage](https://github.com/opencredo/opencredo-react-boilerplate/pull/81#issuecomment-193002967).
